### PR TITLE
improve the llama.go's version displaying && fix go  test and ci on macOS/ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         file: ./coverage.txt
         fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,8 @@ jobs:
         skip-cache: true
         args: --enable-only=govet --tests=false ./...
 
-    - name: Run tests (Ubuntu with coverage)
-      if: matrix.os == 'ubuntu-latest'
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-    - name: Run tests (macOS and Windows)
-      if: matrix.os != 'ubuntu-latest'
-      run: go test -v ./...
+    - name: Run tests
+      run: make test
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: "stable"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,8 @@ jobs:
         go mod tidy
         make
 
-    - uses: golangci/golangci-lint-action@v7
+    - uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.0
         skip-cache: true
         args: --enable-only=govet --tests=false ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ core/build_*/
 
 # Claude Code configuration
 .claude/settings.local.json
+
+# local folder
+.local/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "core/llama.cpp"]
 	path = core/llama.cpp
-	url = https://github.com/Qitmeer/llama.cpp.git
+	url = https://github.com/ggml-org/llama.cpp.git
 [submodule "core/whisper.cpp"]
 	path = core/whisper.cpp
 	url = https://github.com/lochjin/whisper.cpp.git

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 test:
 ifeq ($(OS), Linux)
 	@echo "Running test on Linux"
-	@echo "TODO ./scripts/test.sh"
+	@./scripts/test.sh
 else ifeq ($(OS), Darwin)
 	@echo "Running test on macOS"
 	@./scripts/test.sh

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ else
 	@powershell -ExecutionPolicy Bypass -File ./scripts/build_windows.ps1
 endif
 
+clean-bin:
+	$(RM) $(BUILD_DIR)/bin
 clean:
 	@echo "Cleaning $(BUILD_DIR) directory"
 ifeq ($(OS), Linux)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,18 @@ else
 	@powershell -ExecutionPolicy Bypass -File ./scripts/build_windows.ps1
 endif
 
+test:
+ifeq ($(OS), Linux)
+	@echo "Running test on Linux"
+	@echo "TODO ./scripts/test.sh"
+else ifeq ($(OS), Darwin)
+	@echo "Running test on macOS"
+	@./scripts/test.sh
+else
+	@echo "Running test on Windows or Unknown OS"
+	@echo "TODO ./scripts/test.sh"
+endif
+
 clean-bin:
 	$(RM) $(BUILD_DIR)/bin
 clean:

--- a/app/app.go
+++ b/app/app.go
@@ -11,14 +11,14 @@ import (
 
 func Run() error {
 	app := &cli.App{
-		Name:    "",
+		Name:    "llama.go",
 		Version: version.String(),
 		Authors: []*cli.Author{
 			&cli.Author{
 				Name: "Qitmeer",
 			},
 		},
-		Copyright:            "(c) 2025 Qitmeer",
+		Copyright:            "(c) 2026 Qitmeer",
 		Usage:                "Llama",
 		Flags:                config.AppFlags,
 		EnableBashCompletion: true,

--- a/app/cmds.go
+++ b/app/cmds.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-
 	"github.com/Qitmeer/llama.go/api"
 	"github.com/Qitmeer/llama.go/app/embedding"
 	econfig "github.com/Qitmeer/llama.go/app/embedding/config"
@@ -60,7 +59,7 @@ func versionCmd() *cli.Command {
 		Usage:       "Show llama.go version",
 		Description: "Show llama.go version",
 		Action: func(ctx *cli.Context) error {
-			print(version.String())
+			println(version.Details())
 			return nil
 		},
 	}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ set(BUILD_SHARED_LIBS OFF)
 set(LLAMA_BUILD_COMMON ON)
 set(LLAMA_BUILD_TOOLS ON)
 set(LLAMA_CURL OFF)
+set(LLAMA_OPENSSL ON)
 add_subdirectory(llama.cpp ${CMAKE_BINARY_DIR}/llama)
 
 # whisper.cpp — reuse the ggml already built by llama.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,6 +70,7 @@ include_directories(${SERVER_ASSETS_DIR})
 # core
 set(SRCS
     ${GENERATED_ASSETS}
+    src/build_info.cpp
     src/process_go_bridge_stub.cpp
     src/interactive.cpp
     src/process.cpp

--- a/core/include/core.h
+++ b/core/include/core.h
@@ -2,3 +2,4 @@
 
 #include "process.h"
 #include "embedding.h"
+#include "info.h"

--- a/core/include/info.h
+++ b/core/include/info.h
@@ -1,0 +1,10 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+   const char* get_llama_build_info();
+
+#ifdef __cplusplus
+}
+#endif

--- a/core/src/build_info.cpp
+++ b/core/src/build_info.cpp
@@ -1,0 +1,8 @@
+#include "build-info.h"
+#include <algorithm>
+
+extern "C" {
+    const char* get_llama_build_info() {
+        return llama_build_info();
+    }
+}

--- a/core/src/build_info.cpp
+++ b/core/src/build_info.cpp
@@ -1,5 +1,4 @@
 #include "build-info.h"
-#include <algorithm>
 
 extern "C" {
     const char* get_llama_build_info() {

--- a/core/src/safe_queue.h
+++ b/core/src/safe_queue.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <string>
 #include <queue>
 #include <mutex>
+#include <condition_variable>
 
 class SafeQueue {
 public:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,6 +21,14 @@ buildDir=$(pwd)/build
 echo "core dir:" ${coreDir}
 echo "build dir:" ${buildDir}
 
+# open-ssl
+if [[ "$(uname -s)" == "Linux" ]]; then
+   if ! pkg-config --exists openssl 2>/dev/null; then
+     sudo apt-get update
+     sudo apt-get install -y pkg-config libssl-dev
+   fi
+fi
+
 # cuda
 cudaTag=""
 cudaCmake=""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -89,6 +89,6 @@ cd ./cmd/llama
 go build $cudaTag -ldflags "-X ${versionBuild}" -o $buildDir/bin/llama
 
 echo "Output executable file:${buildDir}/bin/llama"
-$buildDir/bin/llama --version
+$buildDir/bin/llama version
 
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,0 +1,31 @@
+
+echo "📌  go to llama.cpp submodule"
+cd core/llama.cpp
+pwd
+
+tag=$1
+
+if [ -z $tag ]; then
+  # get the latest tag 
+  last_tag=$(git ls-remote --tags origin "refs/tags/b*"|tail -n 1|cut -d/ -f3)
+  tag=$last_tag
+  echo "  ✔ the last remote tag is $tag"
+else
+  echo "  ✔  use a input manually tag: $tag"
+fi
+
+
+# if local exist 
+if git show-ref --tags --quiet "refs/tags/$tag"; then
+  echo "  ✔ Local already has tag: $tag (skip fetch)"
+else
+  echo "  → Fetching $tag from origin..."
+  git fetch origin $tag 
+fi
+
+# checkout $tag
+echo "📌  Checkout $tag"
+git checkout $tag
+
+cd - 
+echo "✅  Done: $tag ready             "

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -20,7 +20,7 @@ if git show-ref --tags --quiet "refs/tags/$tag"; then
   echo "  ✔ Local already has tag: $tag (skip fetch)"
 else
   echo "  → Fetching $tag from origin..."
-  git fetch origin $tag 
+  git fetch origin tag $tag
 fi
 
 # checkout $tag

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,35 @@
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    openssl_cflags=""
+    openssl_ldflags=""
+
+    if command -v pkg-config &> /dev/null; then
+        if pkg-config --exists openssl; then
+            # Only inject search paths; actual -lssl/-lcrypto come from cgo files.
+            openssl_cflags="$(pkg-config --cflags-only-I openssl)"
+            openssl_ldflags="$(pkg-config --libs-only-L openssl)"
+        elif pkg-config --exists openssl@3; then
+            openssl_cflags="$(pkg-config --cflags-only-I openssl@3)"
+            openssl_ldflags="$(pkg-config --libs-only-L openssl@3)"
+        fi
+    fi
+
+    if [[ -z "${openssl_ldflags}" ]] && command -v brew &> /dev/null; then
+        brew_prefix="$(brew --prefix openssl@3 2>/dev/null || true)"
+        if [[ -z "${brew_prefix}" ]]; then
+            brew_prefix="$(brew --prefix openssl 2>/dev/null || true)"
+        fi
+        if [[ -n "${brew_prefix}" ]]; then
+            openssl_cflags="-I${brew_prefix}/include"
+            openssl_ldflags="-L${brew_prefix}/lib"
+        fi
+    fi
+
+    if [[ -n "${openssl_cflags}" ]]; then
+        export CGO_CFLAGS="${CGO_CFLAGS:-} ${openssl_cflags}"
+    fi
+    if [[ -n "${openssl_ldflags}" ]]; then
+        export CGO_LDFLAGS="${CGO_LDFLAGS:-} ${openssl_ldflags}"
+    fi
+fi
+
+go test -v ./...

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [[ "$(uname -s)" == "Darwin" ]]; then
     openssl_cflags=""
     openssl_ldflags=""
@@ -30,6 +32,37 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     if [[ -n "${openssl_ldflags}" ]]; then
         export CGO_LDFLAGS="${CGO_LDFLAGS:-} ${openssl_ldflags}"
     fi
+
+    go test -v ./...
 fi
 
-go test -v ./...
+if [[ "$(uname -s)" == "Linux" ]]; then
+    openssl_cflags=""
+    openssl_ldflags=""
+
+    if command -v pkg-config &> /dev/null; then
+        if pkg-config --exists openssl; then
+            # Only inject search paths; actual -lssl/-lcrypto come from cgo files.
+            openssl_cflags="$(pkg-config --cflags-only-I openssl)"
+            openssl_ldflags="$(pkg-config --libs-only-L openssl)"
+        elif pkg-config --exists openssl@3; then
+            openssl_cflags="$(pkg-config --cflags-only-I openssl@3)"
+            openssl_ldflags="$(pkg-config --libs-only-L openssl@3)"
+        fi
+    fi
+
+    if [[ -n "${openssl_cflags}" ]]; then
+        export CGO_CFLAGS="${CGO_CFLAGS:-} ${openssl_cflags}"
+    fi
+    if [[ -n "${openssl_ldflags}" ]]; then
+        export CGO_LDFLAGS="${CGO_LDFLAGS:-} ${openssl_ldflags}"
+    fi
+
+    if [[ -d "/usr/local/cuda" ]] && command -v nvcc &> /dev/null; then
+        tags="-tags cuda"
+    fi
+
+    go test $tags -v ./...
+fi
+
+

--- a/server/service.go
+++ b/server/service.go
@@ -59,7 +59,7 @@ func (s *Service) Start() error {
 	if err != nil {
 		return err
 	}
-	log.Info(fmt.Sprintf("Listening on %s (version %s)", ln.Addr(), version.String()))
+	log.Info(fmt.Sprintf("Listening on %s (%s) ", ln.Addr(), version.Details()))
 	s.srvr = &http.Server{
 		Handler: nil,
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -5,6 +5,7 @@ package version
 import (
 	"bytes"
 	"fmt"
+	"github.com/Qitmeer/llama.go/wrapper"
 	"strings"
 )
 
@@ -65,6 +66,14 @@ func String() string {
 	}
 
 	return version
+}
+
+func Details() string {
+	return fmt.Sprintf("llama.go version %v (llamacpp %v)", String(), LlamaCppVersion())
+}
+
+func LlamaCppVersion() string {
+	return wrapper.LLamaCppBulidInfo()
 }
 
 // normalizeSemString returns the passed string stripped of all characters

--- a/wrapper/bridge.go
+++ b/wrapper/bridge.go
@@ -193,6 +193,11 @@ func GetCommonParams() CommonParams {
 	return CommonParams{EndpointProps: bool(ret.endpoint_props)}
 }
 
+func LLamaCppBulidInfo() string {
+	ret := C.get_llama_build_info()
+	return C.GoString(ret)
+}
+
 // IsLlamaRunning reports whether the llama_core inference loop is active (model loaded and serving).
 func IsLlamaRunning() bool {
 	return bool(C.llama_is_running())


### PR DESCRIPTION
1. upgrade the submodule link to the official llama.cpp repository so the tags are easier to track.
2. llama.go now prints its own version together with the `llama.cpp` build-info, e.g.:
```
llama.go version 0.1.1+dev-98b29de (llamacpp b8941-06a811d08)
``` 
3. the process to upgrade/switch a specified `llama.cpp` version is simplified:
```
# go to submodule folder 
git fetch --tags
git checkout <tag_name>
# go back to root folder
make clean-bin all 
```
4. add a make target `clean-bin` to remove the binary, the go link cache might not work correctly after the submodule switch, anyway do a clean rebuild might be safer. 
5. added a helper script at `scripts/tag.sh`, work like :
```
# swtich to the latest tag
./scirpt/tag.sh
# swtich to the appointed tag
./script/tag.sh <tag_name>
```
6. fix `ld error` introduced by the change. `./script/test.sh' is added. triggered by `make test`
```
make test
```
7. fix CI on the macOS/ubuntu, more refactoring in the future PR.
